### PR TITLE
1.0.3: Fix bundles eating items

### DIFF
--- a/.github/workflows/merge_schedule.yml
+++ b/.github/workflows/merge_schedule.yml
@@ -1,0 +1,24 @@
+name: Merge schedule
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # every day at 14:45 UTC
+    - cron: '45 14 * * *'
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        with:
+          merge_method: merge
+          time_zone: 'America/Toronto'
+          require_statuses_success: 'false'
+          automerge_fail_label: 'automerge-fail'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_schedule.yml
+++ b/.github/workflows/merge_schedule.yml
@@ -21,4 +21,4 @@ jobs:
           require_statuses_success: 'false'
           automerge_fail_label: 'automerge-fail'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  packwiz_refresh:
+  version:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node

--- a/index.toml
+++ b/index.toml
@@ -302,7 +302,7 @@ metafile = true
 
 [[files]]
 file = "mods/easy-shulker-boxes.pw.toml"
-hash = "38fd280e531c3e8365ae198033af57072c50a0833b917495720101e38d2618e8"
+hash = "e324cd7bc4956ddf8f807c21b0e9416c77e395c12675bcba84dc9230143aeba8"
 metafile = true
 
 [[files]]

--- a/mods/easy-shulker-boxes.pw.toml
+++ b/mods/easy-shulker-boxes.pw.toml
@@ -1,14 +1,13 @@
 name = "Easy Shulker Boxes"
-filename = "EasyShulkerBoxes-v4.3.7-1.19.2-Fabric.jar"
+filename = "EasyShulkerBoxes-v4.4.0-1.19.2-Fabric.jar"
 side = "both"
 
 [download]
-mode = "url"
-url = "https://cdn.modrinth.com/data/gA5euN8S/versions/covgrvDt/EasyShulkerBoxes-v4.3.7-1.19.2-Fabric.jar"
-hash-format = "sha512"
-hash = "23f5cb26e1fb35db6ba9f1b54fb07faddf30aab2b8414997ecf8c437738229c1d33570560799a1aad647b6b3efc560822b7561f24021903c83d82971344a7a4f"
+url = "https://cdn.modrinth.com/data/gA5euN8S/versions/yS30xnl5/EasyShulkerBoxes-v4.4.0-1.19.2-Fabric.jar"
+hash-format = "sha1"
+hash = "cdff1f47a20a1ee585287b23734ed336e12accd0"
 
 [update]
 [update.modrinth]
 mod-id = "gA5euN8S"
-version = "covgrvDt"
+version = "yS30xnl5"

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "HexxyCraft"
 author = "HexxyCraft Team"
-version = "1.0.2"
+version = "1.0.3"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "cf48efd32ca9bec1ba2edd0450e06dca7f3f85e1f8bcc35a535fde6f56546dfe"
+hash = "d6e9a67dc21c957b6b040edda4ca55f1a6d32455fb48b6d0772977d2e9a17547"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
Checklist:
- [x] Bumped `pack.toml` version number (if merging to `master`)
- [x] Ran installer with `-s both` to ensure server-only mods work
- [x] Ran `packwiz refresh` just before final commit

/schedule