### PR TITLE
new mod: Max Health Fix by DarkhaxDev

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -633,6 +633,11 @@ hash = "301aa7a5d895c33b132f0f55c8822a23ae6bbd20e9fa1ee3aaf0589a15815151"
 metafile = true
 
 [[files]]
+file = "mods/max-health-fix.pw.toml"
+hash = "0f5f8eac3fbb1ce225f557f024c93fd1ccaf4ed7d83cc5d80d65c288726d22db"
+metafile = true
+
+[[files]]
 file = "mods/memoryleakfix.pw.toml"
 hash = "97ffbc7d0e4087777c5e3732780f01958f99d44c4f09fd534bbb8f239d4980a1"
 metafile = true

--- a/mods/max-health-fix.pw.toml
+++ b/mods/max-health-fix.pw.toml
@@ -1,0 +1,13 @@
+name = "Max Health Fix"
+filename = "MaxHealthFix-Fabric-1.19.2-8.0.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/mH8wdmqr/versions/ATq5avMg/MaxHealthFix-Fabric-1.19.2-8.0.1.jar"
+hash-format = "sha1"
+hash = "a624061084c87fd8b7dcc465598d41252b2e684e"
+
+[update]
+[update.modrinth]
+mod-id = "mH8wdmqr"
+version = "ATq5avMg"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "43349559d667e92cb0f4340edc4c07a9113fdb52e5631a7e9347555e332c401a"
+hash = "f5a6968c8f0cd0044b18d9fe43b1ec992785fd49d4ab5be9ec75a15450a46482"
 
 [versions]
 minecraft = "1.19.2"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e6d417bca044b0e9d9750eb6636b4183f4398649434271298263ee613e8d5dc7"
+hash = "4ecb5ff836047959f19c3ab2f46aed640a2f8dd58d6918d665ce1467f1cc9e9b"
 
 [versions]
 minecraft = "1.19.2"


### PR DESCRIPTION
imagine not having your health capped every time you join a world from a bug that Mojang has neglected to fix for [10 bucking years](https://bugs.mojang.com/browse/MC-17876).
sure, bonus health rarely comes up in gameplay that doesn't somehow involve user created content like mods or data packs, but come on Micros**t, there is already a fix!
[/rant] ANYWAY...

Checklist:
- [ ] ~Bumped `pack.toml` version number (if merging to `master`)~ N/A
- [x] Ran installer with `-s both` to ensure server-only mods work (Done, but is this even relevant if I'm not adding a server-only mod?)
- [x] Ran `packwiz refresh` just before final commit